### PR TITLE
Enable DNNL optimal Layout for the supported ops

### DIFF
--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -35,9 +35,11 @@ check the attributes of the op and decide if it should be offloaded to DNNL.
 import logging
 
 import tvm.ir
+from tvm import relay
 from tvm.relay import transform
 from tvm.relay.build_module import bind_params_by_name
 
+from ... import _ffi_api
 from ...dataflow_pattern import wildcard, is_op
 from .register import register_pattern_table
 
@@ -207,7 +209,201 @@ def pattern_table():
     return dnnl_patterns
 
 
-def partition_for_dnnl(mod, params=None):
+def get_optimal_layout_for_conv(input_size, weight_shape, out_shape, paddings, strides, dilates, G):
+    """Get the optimal layout of dnnl, given shape of conv2d.
+
+    Parameters
+    ----------
+    input_size, weight_shape, out_shape, paddings, strides, dilates, G : Int, String
+                                                                         Input argument.
+
+    Returns
+    -------
+    layouts : string
+              The result.
+    """
+    return _ffi_api.get_optimal_layout_for_conv(
+        input_size,
+        weight_shape,
+        out_shape,
+        paddings,
+        strides,
+        dilates,
+        G,
+    )
+
+
+def get_optimal_layout_for_deconv(
+    input_size, weight_shape, out_shape, paddings, output_paddings, strides, dilates, G
+):
+    """Get the optimal layout of dnnl, given shape of tranpose conv2d.
+
+    Parameters
+    ----------
+    input_size, weight_shape, out_shape, paddings, output_paddings, strides, dilates, G
+        : Int, String
+          Input argument.
+
+    Returns
+    -------
+    layouts : string
+              The result.
+    """
+    return _ffi_api.get_optimal_layout_for_deconv(
+        input_size,
+        weight_shape,
+        out_shape,
+        paddings,
+        output_paddings,
+        strides,
+        dilates,
+        G,
+    )
+
+
+def get_shape(tensor):
+    """Get tensor's shape."""
+    if isinstance(tensor, relay.expr.Var):
+        return tensor.type_annotation.concrete_shape
+    elif isinstance(tensor, relay.expr.Constant):
+        return tensor.data.shape
+    elif isinstance(tensor, tvm.ir.tensor_type.TensorType):
+        return tensor.concrete_shape
+    elif isinstance(tensor, tvm.ir.container.Array):
+        return tensor[-1].shape
+    elif isinstance(tensor, relay.expr.Call):
+        return tensor.checked_type.shape
+    else:
+        raise TypeError("Unsupport data type: %s" % type(tensor))
+
+
+def trans_data(input_data, is_weight=False, conv_type=1):
+    if conv_type == 1:
+        data_dic = {"a": "N", "b": "C", "c": "W"}
+        weight_dic = {"a": "O", "b": "I", "c": "W", "d": "G"}
+    elif conv_type == 2:
+        data_dic = {"a": "N", "b": "C", "c": "H", "d": "W"}
+        weight_dic = {"a": "O", "b": "I", "c": "H", "d": "W"}
+        if "e" in input_data:
+            weight_dic = {"a": "G", "b": "O", "c": "I", "d": "H", "e": "W"}
+    elif conv_type == 3:
+        data_dic = {"a": "N", "b": "C", "c": "D", "d": "H", "e": "W"}
+        weight_dic = {"a": "O", "b": "I", "c": "D", "d": "H", "e": "W", "f": "G"}
+
+    dic = weight_dic if is_weight else data_dic
+    res = ""
+
+    for i in input_data:
+        if i.isupper():
+            i = i.lower()
+            res += dic[i]
+            dic[i] = dic[i].lower()
+        elif i.islower():
+            res += dic[i]
+        elif i.isdigit():
+            res += i
+        else:
+            raise ValueError("Unsupport layout format: %s" % input_data)
+    return res
+
+
+def legalize_group_conv(attrs, inputs, types):
+    """Legalize group conv's calculation.
+    Alter weight layout from OIHW to GOIHW"""
+    G = attrs.groups
+    if G == 1:
+        return
+    data, weight = inputs
+    OC, IC, H, W = get_shape(weight)
+    new_attrs = dict(attrs)
+    weight = relay.reshape(weight, (G, OC // G, IC, H, W))
+    new_attrs["kernel_layout"] = "GOIHW"
+    return relay.nn.conv2d(data, weight, **new_attrs)
+
+
+def legalize_group_deconv(attrs, inputs, types):
+    """Legalize group deconv's calculation.
+    Alter weight layout from IOHW to GIOHW"""
+    G = attrs.groups
+    if G == 1:
+        return
+    data, weight = inputs
+    IC, OC, H, W = get_shape(weight)
+    new_attrs = dict(attrs)
+    new_attrs["kernel_layout"] = "GIOHW"
+    weight = relay.reshape(weight, (G, IC // G, OC, H, W))
+    return relay.nn.conv2d_transpose(data, weight, **new_attrs)
+
+
+def alter_conv(attrs, inputs, tinfos, out_type):
+    """The convolution's layout auto-query func for dnnl."""
+
+    data, weight = inputs
+    G = str(attrs.groups)
+    weight_shape = ",".join([str(x) for x in get_shape(weight)])
+    out_shape = ",".join([str(x) for x in get_shape(out_type)])
+    paddings = ",".join([str(x) for x in attrs.get_int_tuple("padding")])
+    strides = ",".join([str(x) for x in attrs.get_int_tuple("strides")])
+    dilates = ",".join([str(x) for x in attrs.get_int_tuple("dilation")])
+    new_attrs = dict(attrs)
+    conv_type = len(get_shape(out_type)) - 2
+
+    res = get_optimal_layout_for_conv(
+        len(get_shape(out_type)), weight_shape, out_shape, paddings, strides, dilates, G
+    )
+    src_df, weight_df, dst_df = res.split(",")
+    new_attrs["data_layout"] = trans_data(src_df, is_weight=False, conv_type=conv_type)
+    new_attrs["kernel_layout"] = trans_data(weight_df, is_weight=True, conv_type=conv_type)
+    new_attrs["out_layout"] = trans_data(dst_df, is_weight=False, conv_type=conv_type)
+    if new_attrs["kernel_layout"] == "HWOIG16g":
+        new_attrs["kernel_layout"] = "HWIOG16g"
+
+    if conv_type == 1:
+        return relay.nn.conv1d(data, weight, **new_attrs)
+    elif conv_type == 2:
+        return relay.nn.conv2d(data, weight, **new_attrs)
+    elif conv_type == 3:
+        return relay.nn.conv3d(data, weight, **new_attrs)
+
+
+def alter_deconv(attrs, inputs, tinfos, out_type):
+    """The transpose convolution's layout auto-query func for dnnl."""
+
+    data, weight = inputs
+    weight_shape = ",".join([str(x) for x in get_shape(weight)])
+    out_shape = ",".join([str(x) for x in get_shape(out_type)])
+    paddings = ",".join([str(x) for x in attrs.get_int_tuple("padding")])
+    output_paddings = ",".join([str(x) for x in attrs.get_int_tuple("output_padding")])
+    strides = ",".join([str(x) for x in attrs.get_int_tuple("strides")])
+    dilates = ",".join([str(x) for x in attrs.get_int_tuple("dilation")])
+    G = str(attrs.groups)
+    new_attrs = dict(attrs)
+    conv_type = len(get_shape(out_type)) - 2
+
+    res = get_optimal_layout_for_deconv(
+        len(get_shape(out_type)),
+        weight_shape,
+        out_shape,
+        paddings,
+        output_paddings,
+        strides,
+        dilates,
+        G,
+    )
+    src_df, weight_df, dst_df = res.split(",")
+    new_attrs["data_layout"] = trans_data(src_df, is_weight=False, conv_type=conv_type)
+    new_attrs["kernel_layout"] = trans_data(weight_df, is_weight=True, conv_type=conv_type)
+    new_attrs["out_layout"] = trans_data(dst_df, is_weight=False, conv_type=conv_type)
+
+    if conv_type == 1:
+        return relay.nn.conv1d_transpose(data, weight, **new_attrs)
+    elif conv_type == 2:
+        return relay.nn.conv2d_transpose(data, weight, **new_attrs)
+    elif conv_type == 3:
+        return relay.nn.conv3d_transpose(data, weight, **new_attrs)
+
+
+def partition_for_dnnl(mod, params=None, alter_layout=True):
     """Partition the graph greedily offloading supported operators to DNNL.
 
     Parameters
@@ -224,16 +420,46 @@ def partition_for_dnnl(mod, params=None):
 
     if params:
         mod["main"] = bind_params_by_name(mod["main"], params)
-    seq = tvm.transform.Sequential(
+    from tvm.relay.testing.temp_op_attr import TempOpAttr
+
+    with TempOpAttr("nn.conv2d", "FTVMLegalize", legalize_group_conv):
+        with TempOpAttr("nn.conv2d_transpose", "FTVMLegalize", legalize_group_deconv):
+            seq = tvm.transform.Sequential(
+                [
+                    transform.CanonicalizeOps(),
+                    transform.InferType(),
+                    transform.SimplifyInference(),
+                    transform.FoldConstant(),
+                    transform.FoldScaleAxis(),
+                    # fold consecutive add ops to simplify pattern `conv2d-bias_add-bn-relu`
+                    transform.SimplifyExpr(),
+                    transform.FoldConstant(),
+                    # alter group conv /deconv layout to `GOIHW` / `GIOHW`
+                    transform.Legalize(),
+                    transform.FoldConstant(),
+                ]
+            )
+            with tvm.transform.PassContext(opt_level=3):
+                mod = seq(mod)
+    if alter_layout:
+        from tvm.relay.testing.temp_op_attr import TempOpAttr
+
+        with TempOpAttr("nn.conv1d", "FTVMAlterOpLayout", alter_conv):
+            with TempOpAttr("nn.conv2d", "FTVMAlterOpLayout", alter_conv):
+                with TempOpAttr("nn.conv3d", "FTVMAlterOpLayout", alter_conv):
+                    with TempOpAttr("nn.conv2d_transpose", "FTVMAlterOpLayout", alter_deconv):
+                        with TempOpAttr("nn.conv3d_transpose", "FTVMAlterOpLayout", alter_deconv):
+                            alter_layout_seq = tvm.transform.Sequential(
+                                [
+                                    transform.AlterOpLayout(),
+                                    transform.FoldConstant(),
+                                ]
+                            )
+                            with tvm.transform.PassContext(opt_level=3):
+                                mod = alter_layout_seq(mod)
+
+    byoc_seq = tvm.transform.Sequential(
         [
-            transform.CanonicalizeOps(),
-            transform.InferType(),
-            transform.SimplifyInference(),
-            transform.FoldConstant(),
-            transform.FoldScaleAxis(),
-            # fold consecutive add ops to simplify pattern `conv2d-bias_add-bn-relu`
-            transform.SimplifyExpr(),
-            transform.FoldConstant(),
             transform.MergeComposite(pattern_table()),
             transform.AnnotateTarget("dnnl"),
             transform.MergeCompilerRegions(),
@@ -241,5 +467,5 @@ def partition_for_dnnl(mod, params=None):
         ]
     )
     with tvm.transform.PassContext(opt_level=3):
-        mod = seq(mod)
+        mod = byoc_seq(mod)
     return mod

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -211,13 +211,13 @@ def pattern_table():
     return dnnl_patterns
 
 
-def get_optimal_layout_for_conv(input_size, weight_shape, out_shape, paddings, strides, dilates, groups):
+def get_optimal_layout_for_conv(weight_shape, out_shape, paddings, strides, dilates, groups):
     """Get the optimal layout of dnnl, given shape of conv2d.
 
     Parameters
     ----------
-    input_size, weight_shape, out_shape, paddings, strides, dilates, groups : Int, String
-                                                                              Input argument.
+    weight_shape, out_shape, paddings, strides, dilates, groups : Int, String
+                                                                  Input argument.
 
     Returns
     -------
@@ -225,7 +225,6 @@ def get_optimal_layout_for_conv(input_size, weight_shape, out_shape, paddings, s
               The result.
     """
     return _ffi_api.get_optimal_layout_for_conv(
-        input_size,
         weight_shape,
         out_shape,
         paddings,
@@ -236,13 +235,13 @@ def get_optimal_layout_for_conv(input_size, weight_shape, out_shape, paddings, s
 
 
 def get_optimal_layout_for_conv_transpose(
-    input_size, weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
+    weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
 ):
     """Get the optimal layout of dnnl, given shape of tranposed conv2d.
 
     Parameters
     ----------
-    input_size, weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
+    weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
         : Int, String
           Input argument.
 
@@ -252,7 +251,6 @@ def get_optimal_layout_for_conv_transpose(
               The result.
     """
     return _ffi_api.get_optimal_layout_for_conv_transpose(
-        input_size,
         weight_shape,
         out_shape,
         paddings,
@@ -282,15 +280,15 @@ def get_shape(tensor):
 def tag2layout(input_data, is_weight=False, conv_type="Conv1D"):
     """Transfer layout, denoted with `a, b, c, d, e`,
     into valid layout (NCHW / OIHW) of TVM."""
-    if conv_type == "Conv1D":
+    if "Conv1D" in conv_type:
         data_dic = {"a": "N", "b": "C", "c": "W"}
         weight_dic = {"a": "O", "b": "I", "c": "W", "d": "G"}
-    elif conv_type == "Conv2D":
+    elif "Conv2D" in conv_type:
         data_dic = {"a": "N", "b": "C", "c": "H", "d": "W"}
         weight_dic = {"a": "O", "b": "I", "c": "H", "d": "W"}
         if "e" in input_data:
             weight_dic = {"a": "G", "b": "O", "c": "I", "d": "H", "e": "W"}
-    elif conv_type == "Conv3D":
+    elif "Conv3D" in conv_type:
         data_dic = {"a": "N", "b": "C", "c": "D", "d": "H", "e": "W"}
         weight_dic = {"a": "O", "b": "I", "c": "D", "d": "H", "e": "W", "f": "G"}
 
@@ -343,7 +341,7 @@ def alter_conv(attrs, inputs, tinfos, out_type):
     conv_type = type(attrs).__name__.split("Attrs")[0]
 
     res = get_optimal_layout_for_conv(
-        len(get_shape(out_type)), weight_shape, out_shape, paddings, strides, dilates, groups
+        weight_shape, out_shape, paddings, strides, dilates, groups
     )
     src_df, weight_df, dst_df = res.split(",")
     new_attrs["data_layout"] = tag2layout(src_df, is_weight=False, conv_type=conv_type)
@@ -375,7 +373,6 @@ def alter_conv_transpose(attrs, inputs, tinfos, out_type):
     conv_type = type(attrs).__name__.split("Attrs")[0]
 
     res = get_optimal_layout_for_conv_transpose(
-        len(get_shape(out_type)),
         weight_shape,
         out_shape,
         paddings,

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -361,8 +361,6 @@ def alter_conv(attrs, inputs, tinfos, out_type):
         weight_df, is_weight=True, conv_type=conv_type
     )
     new_attrs["out_layout"] = validate_layout_for_tvm(dst_df, is_weight=False, conv_type=conv_type)
-    if new_attrs["kernel_layout"] == "HWOIG16g":
-        new_attrs["kernel_layout"] = "HWIOG16g"
 
     if conv_type == 1:
         return relay.nn.conv1d(data, weight, **new_attrs)

--- a/python/tvm/relay/op/contrib/dnnl.py
+++ b/python/tvm/relay/op/contrib/dnnl.py
@@ -91,8 +91,8 @@ _register_external_op_helper("nn.leaky_relu")
 _register_external_op_helper("tanh")
 _register_external_op_helper("sigmoid")
 _register_external_op_helper("nn.softmax")
-_register_external_op_helper("add")
-_register_external_op_helper("multiply")
+# _register_external_op_helper("add")
+# _register_external_op_helper("multiply")
 
 
 def make_conv_pattern(conv_name, with_bias=True, with_eltwise=None):
@@ -211,13 +211,14 @@ def pattern_table():
     return dnnl_patterns
 
 
-def get_optimal_layout_for_conv(weight_shape, out_shape, paddings, strides, dilates, groups):
+def get_optimal_layout_for_conv(data_layout, kernel_layout, weight_shape,
+                                out_shape, paddings, strides, dilates, groups):
     """Get the optimal layout of dnnl, given shape of conv2d.
 
     Parameters
     ----------
-    weight_shape, out_shape, paddings, strides, dilates, groups : Int, String
-                                                                  Input argument.
+    data_layout, kernel_layout,weight_shape, out_shape, paddings, strides, dilates, groups :String
+                                                                                            Input argument.
 
     Returns
     -------
@@ -225,6 +226,8 @@ def get_optimal_layout_for_conv(weight_shape, out_shape, paddings, strides, dila
               The result.
     """
     return _ffi_api.get_optimal_layout_for_conv(
+        data_layout,
+        kernel_layout,
         weight_shape,
         out_shape,
         paddings,
@@ -235,13 +238,13 @@ def get_optimal_layout_for_conv(weight_shape, out_shape, paddings, strides, dila
 
 
 def get_optimal_layout_for_conv_transpose(
-    weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
+    data_layout, kernel_layout, weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
 ):
     """Get the optimal layout of dnnl, given shape of tranposed conv2d.
 
     Parameters
     ----------
-    weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
+    data_layout, kernel_layout, weight_shape, out_shape, paddings, output_paddings, strides, dilates, groups
         : Int, String
           Input argument.
 
@@ -251,6 +254,8 @@ def get_optimal_layout_for_conv_transpose(
               The result.
     """
     return _ffi_api.get_optimal_layout_for_conv_transpose(
+        data_layout,
+        kernel_layout, 
         weight_shape,
         out_shape,
         paddings,
@@ -341,7 +346,8 @@ def alter_conv(attrs, inputs, tinfos, out_type):
     conv_type = type(attrs).__name__.split("Attrs")[0]
 
     res = get_optimal_layout_for_conv(
-        weight_shape, out_shape, paddings, strides, dilates, groups
+        attrs["data_layout"], attrs["kernel_layout"], weight_shape, out_shape, paddings,
+        strides, dilates, groups,
     )
     src_df, weight_df, dst_df = res.split(",")
     new_attrs["data_layout"] = tag2layout(src_df, is_weight=False, conv_type=conv_type)
@@ -373,6 +379,8 @@ def alter_conv_transpose(attrs, inputs, tinfos, out_type):
     conv_type = type(attrs).__name__.split("Attrs")[0]
 
     res = get_optimal_layout_for_conv_transpose(
+        attrs["data_layout"],
+        attrs["kernel_layout"], 
         weight_shape,
         out_shape,
         paddings,

--- a/src/relay/backend/contrib/dnnl/query_layout.cc
+++ b/src/relay/backend/contrib/dnnl/query_layout.cc
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/relay/backend/contrib/dnnl/query_layout.cc
+ * \brief layout auto-query func.
+ */
+
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/transform.h>
+#include <tvm/relay/type.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/registry.h>
+
+#include <fstream>
+#include <numeric>
+#include <regex>
+#include <sstream>
+
+#include "../../utils.h"
+#include "dnnl.hpp"
+
+using dim_t = dnnl_dim_t;
+using dims_t = dnnl_dims_t;
+
+namespace tvm {
+namespace relay {
+namespace contrib {
+
+template <typename T, typename U>
+inline void array_set(T* arr, const U& val, size_t size) {
+  for (size_t i = 0; i < size; ++i) arr[i] = static_cast<T>(val);
+}
+
+template <typename T>
+inline void array_copy(T* dst, const T* src, size_t size) {
+  for (size_t i = 0; i < size; ++i) dst[i] = src[i];
+}
+
+void compute_blocks(dims_t blocks, const dnnl::memory::desc* md) {
+  using format_kind_t = dnnl_format_kind_t;
+  const format_kind_t blocked = dnnl_blocked;
+  if (!(md->data.format_kind == blocked)) {
+    array_set(blocks, 0, md->data.ndims);
+    return;
+  }
+
+  array_set(blocks, 1, md->data.ndims);
+
+  const auto& bd = md->data.format_desc.blocking;
+  for (int iblk = 0; iblk < bd.inner_nblks; ++iblk)
+    blocks[bd.inner_idxs[iblk]] *= bd.inner_blks[iblk];
+}
+
+inline bool has_runtime_strides(const dnnl::memory::desc* md) {
+  using format_kind_t = dnnl_format_kind_t;
+  const format_kind_t blocked = dnnl_blocked;
+  if (!(md->data.format_kind == blocked)) return false;
+  for (int d = 0; d < md->data.ndims; ++d)
+    if (md->data.format_desc.blocking.strides[d] == DNNL_RUNTIME_DIM_VAL) return true;
+  return false;
+}
+
+template <typename T>
+inline void swap(T& t1, T& t2) {
+  T tmp(t1);
+  t1 = t2;
+  t2 = tmp;
+}
+
+template <typename T, typename U, typename F>
+inline void simultaneous_sort(T* vals, T* vals_2nd_level, U* keys, size_t size, F comparator) {
+  if (size == 0) return;
+
+  for (size_t i = 0; i < size - 1; ++i) {
+    bool swapped = false;
+
+    for (size_t j = 0; j < size - i - 1; j++) {
+      auto res = comparator(vals[j], vals[j + 1]);
+      if (res == 0) res = comparator(vals_2nd_level[j], vals_2nd_level[j + 1]);
+
+      if (res > 0) {
+        swap(vals[j], vals[j + 1]);
+        swap(vals_2nd_level[j], vals_2nd_level[j + 1]);
+        swap(keys[j], keys[j + 1]);
+        swapped = true;
+      }
+    }
+
+    if (swapped == false) break;
+  }
+}
+
+std::string md2fmt_tag_str(const dnnl::memory::desc* md) {
+  const auto& blk = md->data.format_desc.blocking;
+
+  dims_t blocks = {0};
+  compute_blocks(blocks, md);
+
+  char dim_chars[DNNL_MAX_NDIMS + 1];
+
+  dims_t ou_blocks = {0};
+  array_copy(ou_blocks, md->data.padded_dims, md->data.ndims);
+
+  bool plain = true;
+  for (int d = 0; d < md->data.ndims; ++d) {
+    dim_chars[d] = (blocks[d] == 1 ? 'a' : 'A') + static_cast<char>(d);
+    if (blocks[d] != 1) plain = false;
+    ou_blocks[d] /= blocks[d];
+  }
+
+  // Can't report meaningful tag for runtime dimensions.
+  if (has_runtime_strides(md)) return "*";
+
+  dims_t strides;
+  array_copy(strides, blk.strides, md->data.ndims);
+
+  simultaneous_sort(strides, ou_blocks, dim_chars, md->data.ndims,
+                    [](dim_t a, dim_t b) { return b - a; });
+
+  dim_chars[md->data.ndims] = '\0';
+
+  std::string s(dim_chars);
+
+  if (!plain) {
+    for (int iblk = 0; iblk < blk.inner_nblks; ++iblk) {
+      char c = ('a' + static_cast<char>(blk.inner_idxs[iblk]));
+      s += (std::to_string(blk.inner_blks[iblk]) + c);
+    }
+  }
+  return s;
+}
+
+dnnl::memory::dims str2num(std::string str_shape, int input_size) {
+  std::string str_reg = "(\\d*)";
+  for (int i = 0; i < input_size - 1; i++) {
+    str_reg.append(",(\\d*)");
+  }
+  std::regex rex(str_reg);
+  std::smatch m;
+  dnnl::memory::dims out_dims;
+  if (std::regex_search(str_shape, m, rex)) {
+    std::transform(m.begin() + 1, m.end(), std::back_inserter(out_dims),
+                   [](const std::string& str) { return std::stoi(str); });
+  } else {
+    LOG(FATAL) << "Unsupported shape for querying optimal dnnl layout: " << str_shape;
+  }
+  return out_dims;
+}
+
+std::string get_optimal_layout_for_conv(int input_size, std::string weight_shape,
+                                        std::string out_shape, std::string paddings,
+                                        std::string strides, std::string dilates, std::string G) {
+  dnnl::engine eng(dnnl::engine::kind::cpu, 0);
+  dnnl::stream s(eng);
+  using tag = dnnl::memory::format_tag;
+  using dt = dnnl::memory::data_type;
+
+  dnnl::memory::dim groups = std::stoi(G);
+  dnnl::memory::dims weight_dims_ = str2num(weight_shape, input_size);
+  dnnl::memory::dims weight_dims = weight_dims_;
+  if (groups > 1) {
+    if (weight_dims_.size() == 5) {
+      weight_dims = {weight_dims_[0] * weight_dims_[1], weight_dims_[2], weight_dims_[3],
+                     weight_dims_[4]};
+    } else {
+      weight_dims[1] = weight_dims[1] * groups;
+    }
+  }
+  dnnl::memory::dims out_dims = str2num(out_shape, input_size);
+  dnnl::memory::dims padding_dims = str2num(paddings, 2 * (input_size - 2));
+  dnnl::memory::dims padding_dims_l(padding_dims.begin(),
+                                    padding_dims.begin() + padding_dims.size() / 2);
+  dnnl::memory::dims padding_dims_r(padding_dims.end() - padding_dims.size() / 2,
+                                    padding_dims.end());
+  dnnl::memory::dims strides_dims = str2num(strides, input_size - 2);
+  dnnl::memory::dims dilates_dims = str2num(dilates, input_size - 2);
+
+  dnnl::memory::dims input_dims = out_dims;
+  input_dims[1] = weight_dims[1];
+  for (int i = 2; i < input_size; i++) {
+    dnnl::memory::dim K = weight_dims[i];
+    dnnl::memory::dim S = strides_dims[i - 2];
+    dnnl::memory::dim D = dilates_dims[i - 2] - 1;
+    dnnl::memory::dim PL = padding_dims_l[i - 2];
+    dnnl::memory::dim PR = padding_dims_r[i - 2];
+    dnnl::memory::dim DK = 1 + (K - 1) * (D + 1);
+    dilates_dims[i - 2] = D;
+    input_dims[i] = out_dims[i] * S - PL - PR + DK - 1;
+  }
+
+  dnnl::memory::dims conv_src_tz = input_dims;
+  dnnl::memory::dims conv_weights_tz = weight_dims;
+  if (groups > 1) {
+    conv_weights_tz = {groups, out_dims[1] / groups, input_dims[1] / groups};
+    conv_weights_tz.insert(conv_weights_tz.end(), weight_dims.begin() + 2, weight_dims.end());
+  }
+  dnnl::memory::dims conv_bias_tz = {out_dims[1]};
+  dnnl::memory::dims conv_dst_tz = out_dims;
+  dnnl::memory::dims conv_strides = strides_dims;
+  dnnl::memory::dims conv_dilates = dilates_dims;
+  dnnl::memory::dims conv_padding_l = padding_dims_l;
+  dnnl::memory::dims conv_padding_r = padding_dims_r;
+
+  auto conv_src_md = dnnl::memory::desc({conv_src_tz}, dt::f32, tag::any);
+  auto conv_weights_md = dnnl::memory::desc({conv_weights_tz}, dt::f32, tag::any);
+  auto conv_dst_md = dnnl::memory::desc({conv_dst_tz}, dt::f32, tag::any);
+
+  auto conv_desc = dnnl::convolution_forward::desc(
+      dnnl::prop_kind::forward_inference, dnnl::algorithm::convolution_direct, conv_src_md,
+      conv_weights_md, conv_dst_md, conv_strides, conv_dilates, conv_padding_l, conv_padding_r);
+
+  auto conv_prim_desc = dnnl::convolution_forward::primitive_desc(conv_desc, eng);
+
+  auto src_format = conv_prim_desc.src_desc();
+  auto weights_format = conv_prim_desc.weights_desc();
+  auto dst_format = conv_prim_desc.dst_desc();
+  std::string src_df, weight_df, dst_df;
+
+  src_df = md2fmt_tag_str(&src_format);
+  weight_df = md2fmt_tag_str(&weights_format);
+  dst_df = md2fmt_tag_str(&dst_format);
+  std::string res = src_df + "," + weight_df + "," + dst_df;
+  return res;
+}
+
+std::string get_optimal_layout_for_deconv(int input_size, std::string weight_shape,
+                                          std::string out_shape, std::string paddings,
+                                          std::string output_paddings, std::string strides,
+                                          std::string dilates, std::string G) {
+  dnnl::engine eng(dnnl::engine::kind::cpu, 0);
+  dnnl::stream s(eng);
+  using tag = dnnl::memory::format_tag;
+  using dt = dnnl::memory::data_type;
+
+  dnnl::memory::dim groups = std::stoi(G);
+  dnnl::memory::dims weight_dims_ = str2num(weight_shape, input_size);
+  dnnl::memory::dims weight_dims = weight_dims_;
+  if (groups > 1) {
+    if (weight_dims_.size() == 5) {
+      weight_dims = {weight_dims_[0] * weight_dims_[1], weight_dims_[2], weight_dims_[3],
+                     weight_dims_[4]};
+    } else {
+      weight_dims[1] = weight_dims[1] * groups;
+    }
+  }
+  dnnl::memory::dims out_dims = str2num(out_shape, input_size);
+  dnnl::memory::dims padding_dims = str2num(paddings, 2 * (input_size - 2));
+  dnnl::memory::dims padding_dims_l(padding_dims.begin(),
+                                    padding_dims.begin() + padding_dims.size() / 2);
+  dnnl::memory::dims padding_dims_r(padding_dims.end() - padding_dims.size() / 2,
+                                    padding_dims.end());
+  dnnl::memory::dims output_padding_dims = str2num(output_paddings, input_size - 2);
+  dnnl::memory::dims strides_dims = str2num(strides, input_size - 2);
+  dnnl::memory::dims dilates_dims = str2num(dilates, input_size - 2);
+
+  dnnl::memory::dims input_dims = out_dims;
+  if (out_dims[1] == weight_dims[0]) {
+    input_dims[1] = weight_dims[1];
+  } else {
+    input_dims[1] = weight_dims[0];
+    std::swap(weight_dims[0], weight_dims[1]);
+  }
+  for (int i = 2; i < input_size; i++) {
+    dnnl::memory::dim K = weight_dims[i];
+    dnnl::memory::dim S = strides_dims[i - 2];
+    dnnl::memory::dim D = dilates_dims[i - 2] - 1;
+    dnnl::memory::dim PL = padding_dims_l[i - 2];
+    dnnl::memory::dim PR = padding_dims_r[i - 2];
+    dnnl::memory::dim OP = output_padding_dims[i - 2];
+    dnnl::memory::dim DK = 1 + (K - 1) * (D + 1);
+    dilates_dims[i - 2] = D;
+    input_dims[i] = (out_dims[i] - DK + PL + PR - OP) / S + 1;
+  }
+
+  dnnl::memory::dims deconv_src_tz = input_dims;
+  dnnl::memory::dims deconv_weights_tz = weight_dims;
+  if (groups > 1) {
+    deconv_weights_tz = {groups, out_dims[1] / groups, input_dims[1] / groups};
+    deconv_weights_tz.insert(deconv_weights_tz.end(), weight_dims.begin() + 2, weight_dims.end());
+  }
+  dnnl::memory::dims deconv_bias_tz = {out_dims[1]};
+  dnnl::memory::dims deconv_dst_tz = out_dims;
+  dnnl::memory::dims deconv_strides = strides_dims;
+  dnnl::memory::dims deconv_dilates = dilates_dims;
+  dnnl::memory::dims deconv_padding_l = padding_dims_l;
+  dnnl::memory::dims deconv_padding_r = padding_dims_r;
+
+  auto deconv_src_md = dnnl::memory::desc({deconv_src_tz}, dt::f32, tag::any);
+  auto deconv_weights_md = dnnl::memory::desc({deconv_weights_tz}, dt::f32, tag::any);
+  auto deconv_dst_md = dnnl::memory::desc({deconv_dst_tz}, dt::f32, tag::any);
+
+  auto deconv_desc = dnnl::deconvolution_forward::desc(
+      dnnl::prop_kind::forward_inference, dnnl::algorithm::deconvolution_direct, deconv_src_md,
+      deconv_weights_md, deconv_dst_md, deconv_strides, deconv_dilates, deconv_padding_l,
+      deconv_padding_r);
+
+  auto deconv_prim_desc = dnnl::deconvolution_forward::primitive_desc(deconv_desc, eng);
+
+  auto src_format = deconv_prim_desc.src_desc();
+  auto weights_format = deconv_prim_desc.weights_desc();
+  auto dst_format = deconv_prim_desc.dst_desc();
+  std::string src_df, weight_df, dst_df;
+
+  src_df = md2fmt_tag_str(&src_format);
+  weight_df = md2fmt_tag_str(&weights_format);
+  dst_df = md2fmt_tag_str(&dst_format);
+  std::string res = src_df + "," + weight_df + "," + dst_df;
+  return res;
+}
+
+TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      *rv = get_optimal_layout_for_conv(args[0], args[1], args[2], args[3], args[4], args[5],
+                                        args[6]);
+    });
+
+TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_deconv")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      *rv = get_optimal_layout_for_deconv(args[0], args[1], args[2], args[3], args[4], args[5],
+                                          args[6], args[7]);
+    });
+
+}  // namespace contrib
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/backend/contrib/dnnl/query_layout.cc
+++ b/src/relay/backend/contrib/dnnl/query_layout.cc
@@ -238,10 +238,10 @@ std::string get_optimal_layout_for_conv(int input_size, std::string weight_shape
   return res;
 }
 
-std::string get_optimal_layout_for_deconv(int input_size, std::string weight_shape,
-                                          std::string out_shape, std::string paddings,
-                                          std::string output_paddings, std::string strides,
-                                          std::string dilates, std::string G) {
+std::string get_optimal_layout_for_conv_transpose(int input_size, std::string weight_shape,
+                                                  std::string out_shape, std::string paddings,
+                                                  std::string output_paddings, std::string strides,
+                                                  std::string dilates, std::string G) {
   dnnl::engine eng(dnnl::engine::kind::cpu, 0);
   dnnl::stream s(eng);
   using tag = dnnl::memory::format_tag;
@@ -329,10 +329,10 @@ TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv")
                                         args[6]);
     });
 
-TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_deconv")
+TVM_REGISTER_GLOBAL("relay.ir.get_optimal_layout_for_conv_transpose")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
-      *rv = get_optimal_layout_for_deconv(args[0], args[1], args[2], args[3], args[4], args[5],
-                                          args[6], args[7]);
+      *rv = get_optimal_layout_for_conv_transpose(args[0], args[1], args[2], args[3], args[4],
+                                                  args[5], args[6], args[7]);
     });
 
 }  // namespace contrib

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -209,11 +209,10 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 
   const auto trans_kernel_layout = tir::BijectiveLayout(kernel_layout, kOIHW);
   if (!trans_kernel_layout.defined()) {
-    reporter->GetDiagCtx().Emit(
-      Diagnostic::Error(reporter->GetSpan())
-      << "conv2d only support kernel layouts that are convertible from "
-      << kOIHW << "."
-      << " The provided layout is: " << kernel_layout);
+    reporter->GetDiagCtx().Emit(Diagnostic::Error(reporter->GetSpan())
+                                << "conv2d only support kernel layouts that are convertible from "
+                                << kOIHW << "."
+                                << " The provided layout is: " << kernel_layout);
     return false;
   }
 
@@ -766,10 +765,9 @@ bool Conv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& a
 
   const auto trans_kernel_layout = tir::BijectiveLayout(kernel_layout, kIOHW);
   ICHECK(trans_kernel_layout.defined())
-      << "Conv2DTransposed only support kernel layouts that are convertible from "
-      << kIOHW << "."
+      << "Conv2DTransposed only support kernel layouts that are convertible from " << kIOHW << "."
       << " But got " << kernel_layout << " " << kIOHW;
-  
+
   Layout out_layout(param->out_layout == "" ? param->data_layout : param->out_layout);
   const auto trans_out_layout = tir::BijectiveLayout(out_layout, kNCHW);
   ICHECK(trans_out_layout.defined())

--- a/src/relay/op/nn/convolution.cc
+++ b/src/relay/op/nn/convolution.cc
@@ -185,12 +185,18 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   const auto* weight = types[1].as<TensorTypeNode>();
   if (data == nullptr) return false;
   static const Layout kNCHW("NCHW");
-  static const Layout kOIHW("OIHW");
+  Layout kOIHW("OIHW");
 
   const auto* param = attrs.as<Conv2DAttrs>();
   ICHECK(param != nullptr);
   const Layout in_layout(param->data_layout);
   const Layout kernel_layout(param->kernel_layout);
+
+  bool is_group = false;
+  if (param->groups > 1 && kernel_layout.name().find("G") != std::string::npos) {
+    kOIHW = Layout("GOIHW");
+    is_group = true;
+  }
 
   const auto trans_in_layout = tir::BijectiveLayout(in_layout, kNCHW);
   if (!trans_in_layout.defined()) {
@@ -204,9 +210,10 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   const auto trans_kernel_layout = tir::BijectiveLayout(kernel_layout, kOIHW);
   if (!trans_kernel_layout.defined()) {
     reporter->GetDiagCtx().Emit(
-        Diagnostic::Error(reporter->GetSpan())
-        << "conv2d only support kernel layouts that are convertible from OIHW."
-        << " The provided layout is: " << kernel_layout);
+      Diagnostic::Error(reporter->GetSpan())
+      << "conv2d only support kernel layouts that are convertible from "
+      << kOIHW << "."
+      << " The provided layout is: " << kernel_layout);
     return false;
   }
 
@@ -244,7 +251,12 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     ICHECK_EQ(param->dilation.size(), 2);
     Array<IndexExpr> wshape;
 
-    if (is_depthwise) {
+    if (is_group) {
+      // infer weight's shape for group convolution
+      wshape = {{param->groups, indexdiv(param->channels, param->groups),
+                 indexdiv(dshape_nchw[1], param->groups), param->kernel_size[0],
+                 param->kernel_size[1]}};
+    } else if (is_depthwise) {
       // infer weight's shape for depthwise convolution
       wshape = {{dshape_nchw[1], indexdiv(param->channels, dshape_nchw[1]), param->kernel_size[0],
                  param->kernel_size[1]}};
@@ -734,12 +746,18 @@ bool Conv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& a
   if (data == nullptr) return false;
 
   static const Layout kNCHW("NCHW");
-  static const Layout kIOHW("IOHW");
+  Layout kIOHW("IOHW");
 
   const Conv2DTransposeAttrs* param = attrs.as<Conv2DTransposeAttrs>();
   ICHECK(param != nullptr);
   const Layout in_layout(param->data_layout);
   const Layout kernel_layout(param->kernel_layout);
+
+  bool is_group = false;
+  if (param->groups > 1 && kernel_layout.name().find("G") != std::string::npos) {
+    kIOHW = Layout("GIOHW");
+    is_group = true;
+  }
 
   const auto trans_in_layout = tir::BijectiveLayout(in_layout, kNCHW);
   ICHECK(trans_in_layout.defined())
@@ -748,9 +766,10 @@ bool Conv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& a
 
   const auto trans_kernel_layout = tir::BijectiveLayout(kernel_layout, kIOHW);
   ICHECK(trans_kernel_layout.defined())
-      << "Conv2DTransposed only support kernel layouts that are convertible from IOHW."
-      << " But got " << kernel_layout;
-
+      << "Conv2DTransposed only support kernel layouts that are convertible from "
+      << kIOHW << "."
+      << " But got " << kernel_layout << " " << kIOHW;
+  
   Layout out_layout(param->out_layout == "" ? param->data_layout : param->out_layout);
   const auto trans_out_layout = tir::BijectiveLayout(out_layout, kNCHW);
   ICHECK(trans_out_layout.defined())
@@ -766,8 +785,17 @@ bool Conv2DTransposeRel(const Array<Type>& types, int num_inputs, const Attrs& a
     ICHECK_EQ(param->kernel_size.size(), 2);
     ICHECK_EQ(param->dilation.size(), 2);
 
-    Array<IndexExpr> wshape({dshape_nchw[1], indexdiv(param->channels, param->groups),
-                             param->kernel_size[0], param->kernel_size[1]});
+    Array<IndexExpr> wshape;
+    if (is_group) {
+      // infer weight's shape for group convolution
+      wshape = {{param->groups, indexdiv(dshape_nchw[1], param->groups),
+                 indexdiv(param->channels, param->groups), param->kernel_size[0],
+                 param->kernel_size[1]}};
+    } else {
+      // infer weight's shape for depthwise convolution
+      wshape = {{dshape_nchw[1], indexdiv(param->channels, param->groups), param->kernel_size[0],
+                 param->kernel_size[1]}};
+    }
 
     wshape = trans_kernel_layout.BackwardShape(wshape);
     dilated_ksize_y = 1 + (param->kernel_size[0] - 1) * param->dilation[0];

--- a/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
+++ b/src/runtime/contrib/dnnl/dnnl_json_runtime.cc
@@ -216,9 +216,9 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     return out_dims;
   }
 
-  dnnl::memory::dims TransformStr2Dims(std::vector<std::string> strs, std::string str_name) {
+  dnnl::memory::dims TransformStr2Dims(std::vector<std::string> strs, bool dilates = false) {
     dnnl::memory::dims out_dims;
-    if (str_name == "dilates") {
+    if (dilates) {
       std::transform(strs.begin(), strs.end(), std::back_inserter(out_dims),
                      [](const std::string& str) { return std::stoi(str) - 1; });
     } else {
@@ -338,10 +338,10 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
     dnnl::memory::dims src_dims = TransDims2Plain(input_shape, data_layout);
     dnnl::memory::dims weights_dims_ = TransDims2Plain(weight_shape, kernel_layout);
     dnnl::memory::dims bias_dims = {channels};
-    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides, "strides");
-    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, "dilates");
-    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l, "padding");
-    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r, "padding");
+    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides);
+    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, true);
+    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l);
+    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r);
     dnnl::memory::dims dst_dims = src_dims;
     dst_dims[1] = channels;
     weights_dims_[0] = channels;
@@ -463,11 +463,11 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
       }
     }
     dnnl::memory::dims bias_dims = {channels};
-    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides, "strides");
-    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, "dilates");
-    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l, "padding");
-    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r, "padding");
-    dnnl::memory::dims out_padding = TransformStr2Dims(str_out_padding, "padding");
+    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides);
+    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, true);
+    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l);
+    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r);
+    dnnl::memory::dims out_padding = TransformStr2Dims(str_out_padding);
     dnnl::memory::dims dst_dims = src_dims;
     dst_dims[1] = channels;
     for (int i = 2; i < src_dims.size(); i++) {
@@ -675,11 +675,11 @@ class DNNLJSONRuntime : public JSONRuntimeBase {
 
     dnnl::memory::dims src_dims = TransDims2Plain(input_shape, layout);
     dnnl::memory::dims dst_dims = TransDims2Plain(out_shape, layout);
-    dnnl::memory::dims kernel_dims = TransformStr2Dims(str_kernel, "kernel");
-    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides, "strides");
-    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, "dilates");
-    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l, "padding");
-    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r, "padding");
+    dnnl::memory::dims kernel_dims = TransformStr2Dims(str_kernel);
+    dnnl::memory::dims strides_dims = TransformStr2Dims(str_strides);
+    dnnl::memory::dims dilates_dims = TransformStr2Dims(str_dilates, true);
+    dnnl::memory::dims padding_dims_l = TransformStr2Dims(str_padding_l);
+    dnnl::memory::dims padding_dims_r = TransformStr2Dims(str_padding_r);
 
     // Memory descriptions.
     auto pool_src_md = dnnl::memory::desc(src_dims, dt::f32, layout_dict[layout]);

--- a/src/tir/ir/data_layout.cc
+++ b/src/tir/ir/data_layout.cc
@@ -412,7 +412,6 @@ BijectiveLayout::BijectiveLayout(Layout src_layout, Layout dst_layout) {
 
   n->src_layout = std::move(src_layout);
   n->dst_layout = std::move(dst_layout);
-
   // To be consistent with previous behavior, a nullptr layout is created
   // when argument is invalid.
   if (GetStoreRule(&n->index_forward_rule, &n->shape_forward_rule, n->src_layout, n->dst_layout)) {

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -65,7 +65,6 @@ def run_and_verify(mod, input, params, target, run_module):
     for mode in ["graph", "vm"]:
         for use_dnnl, alter_layout in [(False, False), (True, False), (True, True)]:
             result_key = mode + ("_dnnl" if use_dnnl else "") + ("_layout" if alter_layout else "")
-            print(result_key)
             if use_dnnl:
                 processed_mod = dnnl.partition_for_dnnl(mod, params, alter_layout)
                 check_dnnl_used(processed_mod)

--- a/tests/python/contrib/test_dnnl.py
+++ b/tests/python/contrib/test_dnnl.py
@@ -881,7 +881,6 @@ def test_model(run_module, dtype="float32"):
     run_and_verify_model("VGG11_bn", run_module, dtype=dtype)
     run_and_verify_model("InceptionV3", run_module, input_shape=(1, 3, 300, 300), dtype=dtype)
     run_and_verify_model("MobileNet1.0", run_module, dtype=dtype)
-    run_and_verify_model("ResNext50_32x4d", run_module, dtype=dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- For group conv, its layout need to be legalized to `GOIHW` first, so that it can run in optimal dnnl layout like `HWIOG16g`. Changes in `Convolution.h` is needed to enable group conv run in `GOIHW` layout.
- `get_optimal_layout_for_conv` and  `get_optimal_layout_for_deconv` functions are registered in `tvm.relay.contrib`.
-  All the blocking shapes of ops need to be transformed into plain shape, like `NCHW`, `OIHW` first in `dnnl codegen`.
- The related test cases has been added as well.